### PR TITLE
Added workaround for Mac OS X 10.11 install issue

### DIFF
--- a/docs/guides/main.rst
+++ b/docs/guides/main.rst
@@ -71,6 +71,14 @@ new versions.
 
 .. _@b33ts: http://twitter.com/b33ts
 
+Installing on Mac OS X 10.11
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+On Mac OS X 1.011 (El Captitan), Apple has enabled System Integrity Protection (SIP),
+and because of SIP, some installation processes may fail, even with ``sudo``, because
+they intrude on protected areas of the system. If this happens, try installing
+beets only for the current user by running ``pip install --user beets``.
+
 Installing on Windows
 ^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
When installing, I got the error that `/System/Library/Frameworks/Python.framework/Versions/2.7/share` could not be created, because it intrudes on the new System Integrity Protection in Mac OS X 10.11 El Capitan. Updated Getting Started doc to offer the workaround of installing with the pip `--user` option.

